### PR TITLE
Add memcached to dependancies

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,7 +11,7 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 
 install_dependance() {
-    ynh_install_app_dependencies sogo stunnel4
+    ynh_install_app_dependencies sogo stunnel4 memcached
 }
 
 config_sogo() {


### PR DESCRIPTION
Hi,

Memcached is missing from dependancies and so on, SOGo is producing errors when running:
```
SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY
```

This add memcached to the dependancies list and fix the problem.
Thanks,