### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES AND CUSTOM HELPERS
 #=================================================
 
-readonly time_zone=$(cat /etc/timezone)
+readonly time_zone=$(timedatectl show --value --property=Timezone)
 # Note we can't use the upstream version helper as this version depends of the Debian package not this package and the value could differ depending of the Debian version
 readonly current_sogo_version="$(dpkg-query --show --showformat='${Version}' sogo | cut -d- -f1)"
 


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.